### PR TITLE
Fix app dismiss notifications on route change effect

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -35,7 +35,7 @@ const App: React.FC = () => {
   useEffect(() => {
     // dismiss notifications on route change
     if (
-      notifications &&
+      notifications.length &&
       previousLocation &&
       location.pathname !== previousLocation?.pathname
     ) {

--- a/src/components/pages/Collection/index.tsx
+++ b/src/components/pages/Collection/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../../contexts';
 import { getRems, media } from '../../../styles';
 import { Status } from '../../../types';
+import { FilterSvg } from '../../svg';
 import {
   styled,
   Page,
@@ -16,7 +17,6 @@ import {
   Small,
   OutlineButton,
 } from '../shared';
-import { FilterSvg } from '../../svg';
 import Loader from './Loader';
 import { SlideProvider, SlideToggle, Slide } from './slide';
 import { useFilterState, Filters } from './filter';

--- a/src/contexts/NotificationsContext.tsx
+++ b/src/contexts/NotificationsContext.tsx
@@ -20,7 +20,7 @@ const NotificationsContext = React.createContext<INotificationsContext>({
 export const NotificationsProvider: React.FC = ({ children }) => {
   const [notifications, setNotifications] = useState<INotification[]>([]);
 
-  const addNotification = (notification: Omit<INotification, 'timestamp'>) => {
+  const addNotification = (notification: Omit<INotification, 'timestamp'>) =>
     setNotifications((oldNotifications) => [
       ...oldNotifications,
       {
@@ -28,7 +28,6 @@ export const NotificationsProvider: React.FC = ({ children }) => {
         timestamp: new Date().getTime(),
       },
     ]);
-  };
 
   const addSuccessNotification = (text: string, heading?: string) =>
     addNotification({
@@ -37,13 +36,12 @@ export const NotificationsProvider: React.FC = ({ children }) => {
       type: NotificationType.Success,
     });
 
-  const addErrorNotification = (text: string, heading?: string) => {
+  const addErrorNotification = (text: string, heading?: string) =>
     addNotification({
       text,
       heading,
       type: NotificationType.Error,
     });
-  };
 
   const dismissNotification = (notification: INotification) =>
     setNotifications((oldNotifications) =>


### PR DESCRIPTION
Prevents notifications added on page mount from getting dismissed before rendering (e.g. available artwork).